### PR TITLE
Set latest optimization feature for YugabyteDB

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -7,7 +7,10 @@ targets:
     password: root
   yugabyte_sql:
     module: postgres
-    connection_string: "host=yb-tservers.default port=5433 dbname=postgres user=yugabyte"
+    # options for YugabyteDB relevant (and faster) for an IoT ingest workload:
+    #  yb_enable_upsert_mode=on does not read before write and on duplicate key, updates it rather than raise an error.
+    #  yb_disable_transactional_writes=on is similar to autocommit each rows, and uses a fast-path insert
+    connection_string: "host=yb-tservers.default port=5433 dbname=postgres user=yugabyte options='-c yb_enable_upsert_mode=on -c yb_disable_transactional_writes=on'"
     # Yugabyte needs this extension for the gen_random_uuid function
     install_extensions: pgcrypto
   yugabyte_cql:

--- a/config.yaml
+++ b/config.yaml
@@ -8,9 +8,10 @@ targets:
   yugabyte_sql:
     module: postgres
     # options for YugabyteDB relevant (and faster) for an IoT ingest workload:
+    #  yb_enable_expression_pushdown=on may help for queries and is off by default only for rolling upgrades
     #  yb_enable_upsert_mode=on does not read before write and on duplicate key, updates it rather than raise an error.
     #  yb_disable_transactional_writes=on is similar to autocommit each rows, and uses a fast-path insert
-    connection_string: "host=yb-tservers.default port=5433 dbname=postgres user=yugabyte options='-c yb_enable_upsert_mode=on -c yb_disable_transactional_writes=on'"
+    connection_string: "host=yb-tservers.default port=5433 dbname=postgres user=yugabyte options='-c yb_enable_expression_pushdown=on -c yb_enable_upsert_mode=on -c yb_disable_transactional_writes=on'"
     # Yugabyte needs this extension for the gen_random_uuid function
     install_extensions: pgcrypto
   yugabyte_cql:

--- a/dbinstall/yugabyte-values.yaml
+++ b/dbinstall/yugabyte-values.yaml
@@ -40,6 +40,7 @@ partition:
 gflags:
   tserver:
     ysql_sequence_cache_minval: 10000
+    ysql_enable_packed_row: true
 
 # nodeSelector:
 #   workload: db


### PR DESCRIPTION
Many improvement have been made to the latest version of YugabyteDB. Some features must always be on (they are not enabled by default to allow rolling upgrades - must be off until all the cluster is on the new version). Some allow some optimizations that are relevant in a IoT ingest context

Always good to set
- [ysql_enable_packed_row](https://github.com/yugabyte/yugabyte-db/issues/3520) set when starting the cluster enable the new way of storing rows with all columns in the same document. Always good to set as soon as all nodes of the cluster are in version 2.15
- [yb_enable_expression_pushdown](https://dev.to/yugabyte/yugabytedb-predicate-push-down-pbb) set for postgresql sessions allow some filtering to be done at storage level. Always good to set when all nodes are in a version supporting pushdowns

Specific to the IoT workload
- [yb_disable_transactional_writes ](https://github.com/yugabyte/yugabyte-db/issues/7809)releases the atomicity of transactions. It is acceptable for bulk load into a table with no secondary index, where we don't need that the visibility of the batch insert is all-or-nothing
- [yb_enable_upsert_mode](https://github.com/yugabyte/yugabyte-db/issues/11269) saves the read that must be done before the writ in order to detect duplicate keys. The behavior is updating the previous row if there's already one, which cannot happen as the primary key is generated

With those, the performance of the YSQL API should be closer to the performance of the YCQL API

Note that you mention some timeouts during the queries, do not hesitate to contact me to check this. The default timeouts are suited for OLTP and can be increased for analytics
