### PR TITLE
Optimization of "newest-per-device" query

### DIFF
--- a/simulator/modules/postgres.py
+++ b/simulator/modules/postgres.py
@@ -209,7 +209,7 @@ def _single_insert_mode(events, use_multiple_tables, batch_size, batch_mode):
 
 
 _indices = [
-    "CREATE INDEX IF NOT EXISTS events_device_ts ON events (device_id, timestamp ASC)",
+    "CREATE INDEX IF NOT EXISTS events_device_ts ON events (device_id ASC, timestamp ASC, temperature ASC)",
     "CREATE INDEX IF NOT EXISTS events_temp ON events (temperature ASC)",
 ]
 

--- a/simulator/modules/postgres.py
+++ b/simulator/modules/postgres.py
@@ -218,7 +218,7 @@ _queries = {
     "temperature-min-max": "SELECT max(temperature), min(temperature) FROM events",
     "temperature-stats": "SELECT max(temperature), avg(temperature), min(temperature) FROM events",
     "temperature-stats-per-device": "SELECT device_id, max(temperature), avg(temperature), min(temperature) FROM events GROUP BY device_id",
-    "newest-per-device": "SELECT e.device_id, e.temperature FROM events e JOIN (SELECT device_id, max(timestamp) as ts FROM events GROUP BY device_id) newest ON e.device_id=newest.device_id AND e.timestamp = newest.ts",
+    "newest-per-device": "SELECT device_id, temperature from (SELECT device_id, temperature, timestamp=max(timestamp) over (partition by device_id) newest FROM events) e where newest",
 }
 
 def queries():


### PR DESCRIPTION
1. The "newest-per-device" was written with a subquery to get the max, which requires reading the table two times. PostgreSQL has window function which allow to do the same in one scan only by calculating `timestamp=max(timestamp) over (partition by device_id) newest` on first scan.
2. the index starting with "device_id" was not defined with ASC and then was hash-sharded in distributed databases like YugabyteDB . Adding ASC makes it range sharded so that the scan is already sorted
3. adding the temperature column a the end if the index makes it a covering index and allows Index Only Scan

Those should be faster on all PostgreSQL and compatible databases. The same should be possible for timescaledb.


Old execution plan on PostgreSQL and PostgreSQL compatible databases, with two scans:
```
explain (costs off)
SELECT e.device_id, e.temperature FROM events e JOIN (
 SELECT device_id, max(timestamp) as ts FROM events GROUP BY device_id
) newest ON e.device_id=newest.device_id AND e.timestamp = newest.ts;

                                                   QUERY PLAN
-----------------------------------------------------------------------------------------------------------------
 Hash Join
   Hash Cond: (((e.device_id)::text = (events.device_id)::text) AND (e."timestamp" = (max(events."timestamp"))))
   ->  Seq Scan on events e
   ->  Hash
         ->  HashAggregate
               Group Key: events.device_id
               ->  Seq Scan on events
```

New execution plan with only one Index Only Scan:
```
  explain (costs off) 
  SELECT device_id, temperature from (
   SELECT device_id, temperature, timestamp=max(timestamp) over (partition by device_id) is_newest FROM events
  ) e where is_newest;

                          QUERY PLAN
--------------------------------------------------------------
 Subquery Scan on e
   Filter: e.newest
   ->  WindowAgg
         ->  Index Only Scan using events_device_ts on events
```